### PR TITLE
[#86874250] Created common logger api.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -20,6 +20,10 @@
 			"Rev": "dc751ce5f266d83c26fae5c0a9093973b29cb61d"
 		},
 		{
+			"ImportPath": "github.com/pivotal-golang/lager",
+			"Rev": "ad0fea85471a401834f7eabfc15bf66a76d0e58d"
+		},
+		{
 			"ImportPath": "github.com/pkg/sftp",
 			"Rev": "506297c9013d2893d5c5daaa9155e7333a1c58de"
 		},

--- a/log/lager.go
+++ b/log/lager.go
@@ -1,0 +1,70 @@
+package log
+
+import (
+	"flag"
+	"fmt"
+	// "io"
+
+	"github.com/pivotal-golang/lager"
+)
+
+func init() {
+	AddFlags(flag.CommandLine)
+	flag.Parse()
+}
+
+func NewLager(log *logger) Logger {
+	var minLagerLogLevel lager.LogLevel
+	switch minLogLevel {
+	case DEBUG:
+		minLagerLogLevel = lager.DEBUG
+	case INFO:
+		minLagerLogLevel = lager.INFO
+	case ERROR:
+		minLagerLogLevel = lager.ERROR
+	case FATAL:
+		minLagerLogLevel = lager.FATAL
+	default:
+		panic(fmt.Errorf("unknown log level: %s", minLogLevel))
+	}
+
+	logger := lager.NewLogger(log.Name)
+	logger.RegisterSink(lager.NewWriterSink(log.Writer, minLagerLogLevel))
+	log.Logger = logger
+
+	return log
+}
+
+// func (l *logger) GetSink() io.Writer {
+// 	return l.Writer
+// }
+
+func (l *logger) Debug(action string, data ...Data) {
+	l.Logger.Debug(action, toLagerData(data...))
+}
+
+func (l *logger) Info(action string, data ...Data) {
+	l.Logger.Info(action, toLagerData(data...))
+}
+
+func (l *logger) Error(action string, err error, data ...Data) {
+	l.Logger.Error(action, err, toLagerData(data...))
+}
+
+func (l *logger) Fatal(action string, err error, data ...Data) {
+	l.Logger.Fatal(action, err, toLagerData(data...))
+}
+
+func toLagerData(givenData ...Data) lager.Data {
+	data := lager.Data{}
+
+	if len(givenData) > 0 {
+		for _, dataArg := range givenData {
+			for key, val := range dataArg {
+				data[key] = val
+			}
+		}
+	}
+
+	return data
+}

--- a/log/lager.go
+++ b/log/lager.go
@@ -35,10 +35,6 @@ func NewLager(log *logger) Logger {
 	return log
 }
 
-// func (l *logger) GetSink() io.Writer {
-// 	return l.Writer
-// }
-
 func (l *logger) Debug(action string, data ...Data) {
 	l.Logger.Debug(action, toLagerData(data...))
 }

--- a/log/log_suite_test.go
+++ b/log/log_suite_test.go
@@ -1,0 +1,63 @@
+package log_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/pivotal-golang/lager"
+	"github.com/pivotalservices/gtils/log"
+
+	"testing"
+)
+
+func TestLog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Log Suite")
+}
+
+type TestLogger struct {
+	log.Logger
+	*TestSink
+}
+
+type TestSink struct {
+	buffer *gbytes.Buffer
+}
+
+func NewTestLogger(component string) *TestLogger {
+	buffer := gbytes.NewBuffer()
+	testSink := NewTestSink(buffer)
+	logger := log.LogFactory(component, log.Lager, buffer)
+	return &TestLogger{logger, testSink}
+}
+
+func NewTestSink(buffer *gbytes.Buffer) *TestSink {
+	return &TestSink{
+		buffer: buffer,
+	}
+}
+
+func (s *TestSink) Buffer() *gbytes.Buffer {
+	return s.buffer
+}
+
+func (s *TestSink) Logs() []lager.LogFormat {
+	logs := []lager.LogFormat{}
+
+	decoder := json.NewDecoder(bytes.NewBuffer(s.buffer.Contents()))
+	for {
+		var log lager.LogFormat
+		if err := decoder.Decode(&log); err == io.EOF {
+			return logs
+		} else if err != nil {
+			panic(err)
+		}
+		logs = append(logs, log)
+	}
+
+	return logs
+}

--- a/log/logapi.go
+++ b/log/logapi.go
@@ -7,16 +7,6 @@ import (
 	"github.com/pivotal-golang/lager"
 )
 
-type LogType uint
-
-type Log struct {
-	Timestamp string `json:"timestamp"`
-	Source    string `json:"source"`
-	Message   string `json:"message"`
-	LogLevel  string `json:"log_level"`
-	Data      Data   `json:"data"`
-}
-
 type Data map[string]interface{}
 
 type Logger interface {
@@ -31,6 +21,8 @@ type logger struct {
 	Name   string
 	Writer io.Writer
 }
+
+type LogType uint
 
 const (
 	Lager LogType = iota

--- a/log/logapi.go
+++ b/log/logapi.go
@@ -1,0 +1,70 @@
+package log
+
+import (
+	"flag"
+	"io"
+
+	"github.com/pivotal-golang/lager"
+)
+
+type LogType uint
+
+type Log struct {
+	Timestamp string `json:"timestamp"`
+	Source    string `json:"source"`
+	Message   string `json:"message"`
+	LogLevel  string `json:"log_level"`
+	Data      Data   `json:"data"`
+}
+
+type Data map[string]interface{}
+
+type Logger interface {
+	Debug(message string, data ...Data)
+	Info(message string, data ...Data)
+	Error(message string, err error, data ...Data)
+	Fatal(message string, err error, data ...Data)
+}
+
+type logger struct {
+	lager.Logger
+	Name   string
+	Writer io.Writer
+}
+
+const (
+	Lager LogType = iota
+)
+
+const (
+	DEBUG = "debug"
+	INFO  = "info"
+	ERROR = "error"
+	FATAL = "fatal"
+)
+
+var (
+	log         *logger
+	minLogLevel string
+)
+
+func AddFlags(flagSet *flag.FlagSet) {
+	flagSet.StringVar(
+		&minLogLevel,
+		"logLevel",
+		string(INFO),
+		"log level: debug, info, error or fatal",
+	)
+}
+
+func SetLogLevel(level string) {
+	minLogLevel = level
+}
+
+func LogFactory(name string, logType LogType, writer io.Writer) Logger {
+	log := &logger{Name: name, Writer: writer}
+	if logType == Lager {
+		return NewLager(log)
+	}
+	return NewLager(log)
+}

--- a/log/logapi_test.go
+++ b/log/logapi_test.go
@@ -1,0 +1,229 @@
+package log_test
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-golang/lager"
+	"github.com/pivotalservices/gtils/log"
+)
+
+var _ = Describe("Logger", func() {
+	var logger *TestLogger
+	var testSink *TestSink
+
+	var component = "my-component"
+	var action = "my-action"
+	var logData = log.Data{
+		"foo":      "bar",
+		"a-number": 7,
+	}
+	var anotherLogData = log.Data{
+		"baz":      "quux",
+		"b-number": 43,
+	}
+
+	BeforeEach(func() {
+		log.SetLogLevel("debug")
+		logger = NewTestLogger(component)
+		testSink = logger.TestSink
+	})
+
+	var TestLagerFormat = func(level lager.LogLevel) {
+		var log lager.LogFormat
+
+		BeforeEach(func() {
+			log = testSink.Logs()[0]
+		})
+
+		It("outputs a properly-formatted message", func() {
+			Ω(log.Message).Should(Equal(fmt.Sprintf("%s.%s", component, action)))
+		})
+
+		It("has a timestamp", func() {
+			expectedTime := float64(time.Now().UnixNano()) / 1e9
+			parsedTimestamp, err := strconv.ParseFloat(log.Timestamp, 64)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(parsedTimestamp).Should(BeNumerically("~", expectedTime, 1.0))
+		})
+
+		It("sets the proper output level", func() {
+			Ω(log.LogLevel).Should(Equal(level))
+		})
+	}
+
+	var TestLagerData = func() {
+		var log lager.LogFormat
+
+		BeforeEach(func() {
+			log = testSink.Logs()[0]
+		})
+
+		It("data contains custom user data", func() {
+			Ω(log.Data["foo"]).Should(Equal("bar"))
+			Ω(log.Data["a-number"]).Should(BeNumerically("==", 7))
+			Ω(log.Data["baz"]).Should(Equal("quux"))
+			Ω(log.Data["b-number"]).Should(BeNumerically("==", 43))
+		})
+	}
+
+	Describe("Debug", func() {
+		Context("with log data", func() {
+			BeforeEach(func() {
+				logger.Debug(action, logData, anotherLogData)
+			})
+
+			TestLagerFormat(lager.DEBUG)
+			TestLagerData()
+		})
+
+		Context("with no log data", func() {
+			BeforeEach(func() {
+				logger.Debug(action)
+			})
+
+			TestLagerFormat(lager.DEBUG)
+		})
+	})
+
+	Describe("Info", func() {
+		Context("with log data", func() {
+			BeforeEach(func() {
+				logger.Info(action, logData, anotherLogData)
+			})
+
+			TestLagerFormat(lager.INFO)
+			TestLagerData()
+		})
+
+		Context("with no log data", func() {
+			BeforeEach(func() {
+				logger.Info(action)
+			})
+
+			TestLagerFormat(lager.INFO)
+		})
+	})
+
+	Describe("Error", func() {
+		var err = errors.New("oh noes!")
+		Context("with log data", func() {
+			BeforeEach(func() {
+				logger.Error(action, err, logData, anotherLogData)
+			})
+
+			TestLagerFormat(lager.ERROR)
+			TestLagerData()
+
+			It("data contains error message", func() {
+				Ω(testSink.Logs()[0].Data["error"]).Should(Equal(err.Error()))
+			})
+		})
+
+		Context("with no log data", func() {
+			BeforeEach(func() {
+				logger.Error(action, err)
+			})
+
+			TestLagerFormat(lager.ERROR)
+
+			It("data contains error message", func() {
+				Ω(testSink.Logs()[0].Data["error"]).Should(Equal(err.Error()))
+			})
+		})
+
+		Context("with no error", func() {
+			BeforeEach(func() {
+				logger.Error(action, nil)
+			})
+
+			TestLagerFormat(lager.ERROR)
+
+			It("does not contain the error message", func() {
+				Ω(testSink.Logs()[0].Data).ShouldNot(HaveKey("error"))
+			})
+		})
+	})
+
+	Describe("Fatal", func() {
+		var err = errors.New("oh noes!")
+		var fatalErr interface{}
+
+		Context("with log data", func() {
+			BeforeEach(func() {
+				defer func() {
+					fatalErr = recover()
+				}()
+
+				logger.Fatal(action, err, logData, anotherLogData)
+			})
+
+			TestLagerFormat(lager.FATAL)
+			TestLagerData()
+
+			It("data contains error message", func() {
+				Ω(testSink.Logs()[0].Data["error"]).Should(Equal(err.Error()))
+			})
+
+			It("data contains stack trace", func() {
+				Ω(testSink.Logs()[0].Data["trace"]).ShouldNot(BeEmpty())
+			})
+
+			It("panics with the provided error", func() {
+				Ω(fatalErr).Should(Equal(err))
+			})
+		})
+
+		Context("with no log data", func() {
+			BeforeEach(func() {
+				defer func() {
+					fatalErr = recover()
+				}()
+
+				logger.Fatal(action, err)
+			})
+
+			TestLagerFormat(lager.FATAL)
+
+			It("data contains error message", func() {
+				Ω(testSink.Logs()[0].Data["error"]).Should(Equal(err.Error()))
+			})
+
+			It("data contains stack trace", func() {
+				Ω(testSink.Logs()[0].Data["trace"]).ShouldNot(BeEmpty())
+			})
+
+			It("panics with the provided error", func() {
+				Ω(fatalErr).Should(Equal(err))
+			})
+		})
+
+		Context("with no error", func() {
+			BeforeEach(func() {
+				defer func() {
+					fatalErr = recover()
+				}()
+
+				logger.Fatal(action, nil)
+			})
+
+			TestLagerFormat(lager.FATAL)
+
+			It("does not contain the error message", func() {
+				Ω(testSink.Logs()[0].Data).ShouldNot(HaveKey("error"))
+			})
+
+			It("data contains stack trace", func() {
+				Ω(testSink.Logs()[0].Data["trace"]).ShouldNot(BeEmpty())
+			})
+
+			It("panics with the provided error (i.e. nil)", func() {
+				Ω(fatalErr).Should(BeNil())
+			})
+		})
+	})
+})


### PR DESCRIPTION
Currently supports the pivotal-golang lager implementation. The
logapi.go file contains the common log interfaces where specialized
implementations exist in their own file (see lager.go for example)