### PR TITLE
Use key file if supplied in place of password

### DIFF
--- a/command/remote_execute_test.go
+++ b/command/remote_execute_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -68,6 +69,22 @@ var _ = Describe("Ssh", func() {
 			CloseSuccess:  true}
 		client = &mockClient{session: session}
 
+	})
+
+	Describe("Client setup", func() {
+		var executer Executer
+		var err error
+		Context("to PCFPSQL host as root with valid password", func() {
+			It("should start successfully", func() {
+				executer, err = NewRemoteExecutor(SshConfig{
+					Username: os.Getenv("PCFPSQL_ENV_SSH_USER"),
+					Password: os.Getenv("PCFPSQL_ENV_SSH_PASS"),
+					Host:     os.Getenv("PCFPSQL_PORT_22_TCP_ADDR"),
+					Port:     22,
+				})
+				Ω(err).ShouldNot(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("Session Run success", func() {


### PR DESCRIPTION
This is a hack to add rudimentary support for connecting to remote
hosts that only support key pair authentication. If a path to a public
key file is passed in in place of a password, attempt to authenticate
to the remote host using the key via the PublicKeys authentication
method. Closes #25. 