### PR TITLE
Add function to allow recreate on restore of PG Database

### DIFF
--- a/persistence/pgdump_test.go
+++ b/persistence/pgdump_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pivotalservices/gtils/command"
 	"github.com/pivotalservices/gtils/mock"
 	"github.com/pivotalservices/gtils/osutils"
-	. "github.com/pivotalservices/gtils/persistence"
+	. "github.com/jghiloni/gtils/persistence"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -129,6 +129,84 @@ var _ = Describe("PgDump", func() {
 				l := mock.NewReadWriteCloser(nil, nil, nil)
 				err := pgDumpInstance.Import(l)
 				Ω(err).ShouldNot(BeNil())
+			})
+		})
+	})
+
+	Context("Restore", func() {
+		var (
+			localFilePath string
+			dir           string
+			output        bytes.Buffer
+		)
+
+		Context("Restore Commands", func() {
+			BeforeEach(func() {
+				dir, _ = ioutil.TempDir("", "spec")
+				localFilePath = path.Join(dir, "lfile")
+
+				pgDumpInstance = &PgDump{
+					IP:       ip,
+					Username: username,
+					Password: password,
+					Port:     5432,
+					Database: "bosh",
+					Caller:   &MockSuccessCall{},
+					RemoteOps: &mockRemoteOps{
+						Writer: &output,
+					},
+				}
+				pgCatchCommand = ""
+			})
+
+			AfterEach(func() {
+				pgDumpInstance = nil
+			})
+
+			It("Should execute the pg command without recreate", func() {
+				controlString := "hello there"
+				l, _ := osutils.SafeCreate(localFilePath)
+				l.WriteString(controlString)
+				l.Close()
+				l, _ = os.Open(localFilePath)
+
+				rescueStdout := os.Stdout
+				r, w, _ := os.Pipe()
+				os.Stdout = w
+
+				pgDumpInstance.RecreateOnRestore = false
+				pgDumpInstance.Import(l)
+
+				w.Close()
+				outBytes, _ := ioutil.ReadAll(r)
+				out := string(outBytes)
+				os.Stdout = rescueStdout
+
+				cmd := fmt.Sprintf("PGPASSWORD=%s %s -h %s -U %s -x -p %d -c  -d %s %s", password, PGDmpRestoreBin, ip, username, 5432, "bosh", "/tmp/archive.backup")
+				Ω(out).Should(Equal(cmd))
+			})
+
+			It("Should execute the pg command with recreate", func() {
+				controlString := "hello there"
+				l, _ := osutils.SafeCreate(localFilePath)
+				l.WriteString(controlString)
+				l.Close()
+				l, _ = os.Open(localFilePath)
+
+				rescueStdout := os.Stdout
+			  r, w, _ := os.Pipe()
+			  os.Stdout = w
+
+				pgDumpInstance.RecreateOnRestore = true
+				pgDumpInstance.Import(l)
+
+			  w.Close()
+			  outBytes, _ := ioutil.ReadAll(r)
+				out := string(outBytes)
+			  os.Stdout = rescueStdout
+
+				cmd := fmt.Sprintf("PGPASSWORD=%s %s -h %s -U %s -x -p %d -c -C -d %s %s", password, PGDmpRestoreBin, ip, username, 5432, "bosh", "/tmp/archive.backup")
+				Ω(out).Should(Equal(cmd))
 			})
 		})
 	})

--- a/persistence/pgdump_test.go
+++ b/persistence/pgdump_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pivotalservices/gtils/command"
 	"github.com/pivotalservices/gtils/mock"
 	"github.com/pivotalservices/gtils/osutils"
-	. "github.com/jghiloni/gtils/persistence"
+	. "github.com/pivotalservices/gtils/persistence"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/persistence/types.go
+++ b/persistence/types.go
@@ -5,14 +5,15 @@ import "github.com/pivotalservices/gtils/command"
 //PgDump - an object which can handle pgres dumps
 type PgDump struct {
 	sshCfg    command.SshConfig
-	IP        string
-	Port      int
-	Database  string
-	Username  string
-	Password  string
-	DbFile    string
-	Caller    command.Executer
-	RemoteOps remoteOperationsInterface
+	IP                string
+	Port              int
+	Database          string
+	Username          string
+	Password          string
+	DbFile            string
+	RecreateOnRestore bool
+	Caller            command.Executer
+	RemoteOps         remoteOperationsInterface
 }
 
 //MysqlDump - an object which can handle mysql dumps


### PR DESCRIPTION
This will facilitate a CF Ops plugin we're writing at ECS to backup/restore the bosh database. Tests pass, new tests added, and should be written in such a way that existing code is not affected.