### PR TITLE
Add UAA client token auth

### DIFF
--- a/uaa/uaa_token.go
+++ b/uaa/uaa_token.go
@@ -11,10 +11,10 @@ import (
 )
 
 //GetToken -
-func GetToken(uaaURL, opsManagerUsername, opsManagerPassword, clientID, clientSecret string) (token string, err error) {
+func GetToken(uaaURL, opsManagerUsername, opsManagerPassword, clientID, clientSecret, grantType string) (token string, err error) {
 	var res *http.Response
 	params := url.Values{
-		"grant_type":    {"password"},
+		"grant_type":    {grantType},
 		"response_type": {"token"},
 		"username":      {opsManagerUsername},
 		"password":      {opsManagerPassword},

--- a/uaa/uaa_token_test.go
+++ b/uaa/uaa_token_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -64,10 +65,24 @@ func NewErrorTestServer(server *ghttp.Server) *ghttp.Server {
 }
 
 func NewTestServer(server *ghttp.Server, token string) *ghttp.Server {
+	expectedFormParams := url.Values{
+		"grant_type":    {"password"},
+		"response_type": {"token"},
+		"username":      {"fakeuser"},
+		"password":      {"fakepass"},
+		"client_id":     {"opsman"},
+		"client_secret": {""},
+	}
 	tokenJson := getFakeToken("./fixtures/token_response.json", token, "", "")
+
 	successTokenHandler := ghttp.RespondWith(http.StatusOK, tokenJson)
+	successFormHandler := ghttp.VerifyForm(expectedFormParams)
+
 	server.AppendHandlers(
-		successTokenHandler,
+		ghttp.CombineHandlers(
+			successFormHandler,
+			successTokenHandler,
+		),
 	)
 	return server
 }


### PR DESCRIPTION
Changes `GetToken()` to accept an a `grantType` argument. Allows the use of UAA 'clients' (grant type `client_credentials`) as well as 'users' (grant type `password`).

Context from [User Account and Authentication - A note on Tokens](https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-Tokens.md#users-and-clients-and-other-actors):
> A user is often represented as a live person, or a process running.
> A client is an application that acts on behalf of a user or act on its own.